### PR TITLE
Fix type errors from prisma.

### DIFF
--- a/src/domain/use-cases/dish/create-sched-dish.ts
+++ b/src/domain/use-cases/dish/create-sched-dish.ts
@@ -24,6 +24,12 @@ export class CreateSchedDish implements CreateSchedDishUseCase {
       }
     });
 
+    if(!dish) {
+      throw CustomError.notFound(
+        `The dish with ID ${schedDishDto.dishId} does not exist.`
+      );
+    }
+
     //al ya haber validado que este platillo es de la misma cocina tambien valida que el usuario pertenece a esa cocina.
     if (dish!.cocinaId !== schedDishDto.kitchenId) {
       throw CustomError.unAuthorized(


### PR DESCRIPTION
To fix the errors is necessary validate that the dish exists. The error accurred because we didn't do this validation and this code was trying to search one invalid kitchen no registered in the database.