### PR TITLE
fix errors when uploading images consecutively.

### DIFF
--- a/src/configuration/plugins/cloudinary.adapter.ts
+++ b/src/configuration/plugins/cloudinary.adapter.ts
@@ -21,13 +21,16 @@ export const cloudinaryAdapter: ICloudinaryAdapter = {
 
   uploadFileFromPath: async (filePath: string, folder: string, fileName: string): Promise<{ url: string; publicId: string }> => {
     try {
+        //Eliminar la extensión del fileName
+        const cleanFileName = fileName.replace(/\.[^/.]+$/, ''); // Elimina cualquier extesión.
+
         const result = await cloudinary.uploader.upload(
           filePath, 
           {
             use_filename: true,//Si es true, cloudinary usará el nombre del archivo original, si es false, cloudinary usará un nombre aleatorio.
             unique_filename: false, //Si es true, cloudinary agregará un sufijo al nombre del archivo para hacerlo único.
             overwrite: false, //Si es true, cloudinary sobreescribirá el archivo si ya existe.
-            public_id: fileName, //El nombre que tendrá el archivo en cloudinary.
+            public_id: cleanFileName, //El nombre que tendrá el archivo en cloudinary.
             folder,
           }
         );
@@ -41,11 +44,13 @@ export const cloudinaryAdapter: ICloudinaryAdapter = {
 
   uploadFileFromBuffer: async (fileBuffer: Buffer, folder: string, fileName: string): Promise<{ url: string; publicId: string }> => {
     return new Promise((resolve, reject) => {
-      const uploadStream = cloudinary.uploader.upload_stream(
+      //Eliminar la extensión del fileName
+      const cleanFileName = fileName.replace(/\.[^/.]+$/, ''); // Elimina cualquier extesión.
+      cloudinary.uploader.upload_stream(
 
         {
           folder,
-          public_id: fileName, // Opcional: Si quieres mantener el nombre del archivo
+          public_id: cleanFileName, // Opcional: Si quieres mantener el nombre del archivo
           use_filename: true,
           unique_filename: false,
           overwrite: false,

--- a/src/configuration/plugins/uuid.adapter.ts
+++ b/src/configuration/plugins/uuid.adapter.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
 export const uuidAdapter = {
-  v4: uuidv4(),
+  v4: uuidv4,
 }

--- a/src/domain/use-cases/dish/create-dish.ts
+++ b/src/domain/use-cases/dish/create-dish.ts
@@ -40,7 +40,7 @@ export class CreateDish implements CreateDishUseCase {
 
     //ejeutar el fileUploadSingle para subir la imagen del platillo
     const fileUploaded = await this.fileUploadSingle.execute( file, folder, validExtensions );
-    createDishDto.imagePath = fileUploaded.url || fileUploaded.fileName;
+    createDishDto.imagePath = fileUploaded.url || fileUploaded.fileName; //TODO: Parche mientras se adapta el retorno del FileSystemeFileUpload y el CloudinaryFileUpload.
     /*Obtener todos los sides por IDs para validar para que el side exista y obtener el kitchenId de cada side
     y comparar que el kitchenId de cada side pertenece a el mismo kitchenId de la cocina al que se le quiere agregar*/
     if (createDishDto.sidesId) {
@@ -64,11 +64,12 @@ export class CreateDish implements CreateDishUseCase {
     }
 
     try{
-      const dishCreated = await this.dishRepository.createDish(createDishDto);
+      const dishCreated = await this.dishRepository.createDish(createDishDto); //se podría almacenar el id de la imagen de clodinary en la base de datos.
       return {dish: dishCreated}
     } catch (error) {
       const deleteUploadedFile = await this.deleteUploadedFile.execute(fileUploaded.publicId);
       //?--> Estaría ultra chido hacer que si falla el eliminar la imagen subida se mande un correo o algo así al admin.
+      //TODO: MENAJEAR POSIBLES ERRORES SI FALLA EL DELETEUPLOADFILE TAMBIEN.
       throw CustomError.internalServer(`Error creating dish - deleteUploadedFile: ${deleteUploadedFile.result}`);
     }
 

--- a/src/domain/use-cases/file-upload/file-upload-single.ts
+++ b/src/domain/use-cases/file-upload/file-upload-single.ts
@@ -4,9 +4,9 @@ import { CustomError } from "../../errors";
 import { uuidAdapter } from "../../../configuration/plugins/uuid.adapter";
 
 interface FileUploadResult {
-  url: string;
-  publicId: string;
-  fileName?: string;
+  url: string; //solo para el cloudinary-file-upload.datasource.impl.ts 
+  publicId: string; //solo para el cloudinary-file-upload.datasource.impl.ts
+  fileName?: string; //*solo para el file-system-file-upload.datasource.impl.ts -> SOLO ESTO RETORNA. 
 }
 
 interface FileUploadSingleUseCase {
@@ -19,8 +19,7 @@ interface FileUploadSingleUseCase {
 
 export class FileUploadSingle implements FileUploadSingleUseCase {
   constructor(
-    private readonly fileUploadRepository: FileUploadRepository,
-    private readonly uuid: string = uuidAdapter.v4
+    private readonly fileUploadRepository: FileUploadRepository, //TODO: HACER QUE COINCIDA EL RETORNO DEL FILE-UPLOAD-DATA-SOURCE-IMPL CON EL DE CLOUDINARY.
   ) {}
 
   async execute(
@@ -35,8 +34,9 @@ export class FileUploadSingle implements FileUploadSingleUseCase {
     const fileExtension = file.mimetype.split('/').at(1) ?? ''; //agarramos la extesión del archivo: 'image/jpg' -> 'jpg'.
     if( !validExtensions.includes(fileExtension) ){ //verificamos si la extensión del archivo es válida.
       throw CustomError.badRequest(`invalid file extension, valid extensions: ${validExtensions.join(', ')}`);
-    }    
-    const fileName = `${this.uuid}.${fileExtension}`; //creamos el nombre del archivo.
+    }
+    const uuid = uuidAdapter.v4(); //generamos un uuid para el nombre del archivo.
+    const fileName = `${uuid}.${fileExtension}`; //creamos el nombre del archivo.
     const uploadedFile: object =  await this.fileUploadRepository.fileUploadSingle(
       folder, 
       fileName,


### PR DESCRIPTION
1.  remove the execution of the method when it starts. uuidAdapter.
2.  refactor FileUploadSingle use case. use the uuidAdapter.v4 in execution.
3.  add comments in create-dish use case.
4. clean file name extentions of uploadFileFromPath, uploadFileFromBuffer from cloudinaryAdapter.